### PR TITLE
Make sure man directory exists first

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,6 +107,7 @@ gadget	:	$(OBJECTS)
 install	:	$(GADGET)
 		strip $(GADGET)
 		cp $(GADGET) /usr/local/bin/
+		mkdir -p /usr/local/man/man1/
 		cp gadget.1 /usr/local/man/man1/
 
 ##########################################################################


### PR DESCRIPTION
`man1` might not exist on install. Make sure it does first.
