### PR TITLE
userguide: Weightjones uses maxcons, not consumption

### DIFF
--- a/docs/userguide/index.Rmd
+++ b/docs/userguide/index.Rmd
@@ -1054,9 +1054,9 @@ p_{3} + p_{4}x & \textrm{otherwise}
 
 where:
 $<\Delta t>$ is the length of the timestep, as a fraction of year
-$<$ C $>$ is the consumption (see section \@ref(sec-consumption)
+$<$ C $>$ is the consumption, calcluated by $M \psi$ (see \@ref(sec-preypreference), equation \@ref(eq:maxcons) & \@ref(eq:feedlevel) respectively)
 $<$ T $>$ is the temperature
-$<\psi>$ is the feeding level (see section \@ref(sec-consumption)
+$<\psi>$ is the feeding level (see \@ref(sec-preypreference), equation \@ref(eq:feedlevel))
 $<W_{ref}>$ is the reference weight
 
 


### PR DESCRIPTION
@bthe Any thoughts on this? the ``C`` in the WeightJones documentation seems flat out wrong to me.

Instead of C, we actually use ``Fphi[i] * MaxCon[i]``:
https://github.com/gadget-framework/gadget2/blob/508b993a2cbbc3304cad25f8ee3f65cca1df0466/src/growthcalc.cc#L340

These come from getFphi / getMaxConsumption:
https://github.com/gadget-framework/gadget2/blob/508b993a2cbbc3304cad25f8ee3f65cca1df0466/src/stockmemberfunctions.cc#L99-L100

...from fphi / maxcons:
https://github.com/gadget-framework/gadget2/blob/508b993a2cbbc3304cad25f8ee3f65cca1df0466/src/include/stockpredator.h#L64-L75

From the calculation of max consumption:
https://github.com/gadget-framework/gadget2/blob/508b993a2cbbc3304cad25f8ee3f65cca1df0466/src/stockpredator.cc#L158-L162

Hopefully it's true, since it'll be easier to implement in gadget3 :)